### PR TITLE
feat: Improve error and warning visibility

### DIFF
--- a/media/error-icon.svg
+++ b/media/error-icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="red"/>
+</svg>

--- a/media/warning-icon.svg
+++ b/media/warning-icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="50,10 90,90 10,90" fill="yellow"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,44 @@
     ],
     "configuration": {},
     "submenus": [ { "id": "pine.mysubmenuNonPineFile", "label": " Pine Script v5" } ],
+    "colors": [
+      {
+        "id": "pine.errorBackground",
+        "description": "Background color for error highlights.",
+        "defaults": {
+          "dark": "rgba(255, 0, 0, 0.1)",
+          "light": "rgba(255, 0, 0, 0.1)",
+          "highContrast": "rgba(255, 0, 0, 0.1)"
+        }
+      },
+      {
+        "id": "pine.warningBackground",
+        "description": "Background color for warning highlights.",
+        "defaults": {
+          "dark": "rgba(255, 255, 0, 0.1)",
+          "light": "rgba(255, 255, 0, 0.1)",
+          "highContrast": "rgba(255, 255, 0, 0.1)"
+        }
+      },
+      {
+        "id": "pine.errorGutterIcon",
+        "description": "Color for the error gutter icon. (Note: Current SVG icon has fixed color)",
+        "defaults": {
+          "dark": "#FF0000",
+          "light": "#FF0000",
+          "highContrast": "#FF0000"
+        }
+      },
+      {
+        "id": "pine.warningGutterIcon",
+        "description": "Color for the warning gutter icon. (Note: Current SVG icon has fixed color)",
+        "defaults": {
+          "dark": "#FFFF00",
+          "light": "#FFFF00",
+          "highContrast": "#FFFF00"
+        }
+      }
+    ],
     "commands": [
       { "command": "pine.mysubmenuNonPineFile", "title": "Pine Script Options" , "category": "navigation", "when": "!editorLangId == pine" }, { "command": "pine.mysubmenu2"          , "title": "Pine Script Options" , "category": "navigation", "when": "editorLangId == pine"  },
       { "command": "pine.typify"              , "title": "Typify Variables"    , "category": "navigation"                                  }, { "command": "pine.completionAccepted"  , "title": "Completion Accepted"                                                             },

--- a/src/PineLint.ts
+++ b/src/PineLint.ts
@@ -106,11 +106,15 @@ export class PineLint {
    * Updates the diagnostics for the active document.
    * @param dataGroups - The groups of data to update the diagnostics with.
    */
-  static async updateDiagnostics(...dataGroups: any[][]): Promise<void> {
-    if (VSCode.ActiveTextEditor) {
-      VSCode.ActiveTextEditor.setDecorations(errorDecorationType, []);
-      VSCode.ActiveTextEditor.setDecorations(warningDecorationType, []);
+   static async updateDiagnostics(documentUri: vscode.Uri, ...dataGroups: any[][]): Promise<void> {
+    const targetEditor = vscode.window.visibleTextEditors.find(
+      editor => editor.document.uri.toString() === documentUri.toString()
+    );
+    if (targetEditor) {
+      targetEditor.setDecorations(errorDecorationType, []);
+      targetEditor.setDecorations(warningDecorationType, []);
     }
+     
 
     const diagnostics: vscode.Diagnostic[] = []
     const errorDecorationRanges: vscode.Range[] = [];

--- a/src/PineLint.ts
+++ b/src/PineLint.ts
@@ -107,7 +107,11 @@ export class PineLint {
    * @param dataGroups - The groups of data to update the diagnostics with.
    */
    static async updateDiagnostics( ...dataGroups: any[][]): Promise<void> {
-    const documentUri: vscode.Uri = VSCode.Uri
+    const activeEditor = vscode.window.activeTextEditor;
+    if (!activeEditor) {
+      return;
+    }
+    const documentUri = activeEditor.document.uri;
     const targetEditor = vscode.window.visibleTextEditors.find(
       editor => editor.document.uri.toString() === documentUri.toString()
     );

--- a/src/PineLint.ts
+++ b/src/PineLint.ts
@@ -159,9 +159,9 @@ export class PineLint {
       PineLint.setDiagnostics(uri, diagnostics)
     }
 
-    if (VSCode.ActiveTextEditor) {
-      VSCode.ActiveTextEditor.setDecorations(errorDecorationType, errorDecorationRanges);
-      VSCode.ActiveTextEditor.setDecorations(warningDecorationType, warningDecorationRanges);
+    if (targetEditor) {
+      targetEditor.setDecorations(errorDecorationType, errorDecorationRanges);
+      targetEditor.setDecorations(warningDecorationType, warningDecorationRanges);
     }
   }
   /**

--- a/src/PineLint.ts
+++ b/src/PineLint.ts
@@ -106,7 +106,8 @@ export class PineLint {
    * Updates the diagnostics for the active document.
    * @param dataGroups - The groups of data to update the diagnostics with.
    */
-   static async updateDiagnostics(documentUri: vscode.Uri, ...dataGroups: any[][]): Promise<void> {
+   static async updateDiagnostics( ...dataGroups: any[][]): Promise<void> {
+    const documentUri: vscode.Uri = VSCode.Uri
     const targetEditor = vscode.window.visibleTextEditors.find(
       editor => editor.document.uri.toString() === documentUri.toString()
     );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ export let errorDecorationType: vscode.TextEditorDecorationType;
 export let warningDecorationType: vscode.TextEditorDecorationType;
 
 export function deactivate() {
+  errorDecorationType.dispose() 
+  warningDecorationType.dispose()
   PineLint.versionClear()
   PineLint.handleDocumentChange()
   return undefined

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,11 +12,15 @@ export let errorDecorationType: vscode.TextEditorDecorationType;
 export let warningDecorationType: vscode.TextEditorDecorationType;
 
 export function deactivate() {
-  errorDecorationType.dispose() 
-  warningDecorationType.dispose()
-  PineLint.versionClear()
-  PineLint.handleDocumentChange()
-  return undefined
+  if (errorDecorationType) {
+    errorDecorationType.dispose();
+  }
+  if (warningDecorationType) {
+    warningDecorationType.dispose();
+  }
+  PineLint.versionClear();
+  PineLint.handleDocumentChange();
+  return undefined;
 }
 
 let timerStart: number = 0

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,9 @@ import { checkForNewVersionAndShowChangelog } from './newVersionPopUp'
 import * as vscode from 'vscode'
 import { PineCompletionService } from './PineCompletionService'
 
+export let errorDecorationType: vscode.TextEditorDecorationType;
+export let warningDecorationType: vscode.TextEditorDecorationType;
+
 export function deactivate() {
   PineLint.versionClear()
   PineLint.handleDocumentChange()
@@ -38,6 +41,16 @@ export async function activate(context: vscode.ExtensionContext) {
   // Set context
   VSCode.setContext(context)
   Class.setContext(context)
+
+  errorDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: new vscode.ThemeColor('pine.errorBackground'),
+    gutterIconPath: context.asAbsolutePath('media/error-icon.svg'),
+  });
+
+  warningDecorationType = vscode.window.createTextEditorDecorationType({
+    backgroundColor: new vscode.ThemeColor('pine.warningBackground'),
+    gutterIconPath: context.asAbsolutePath('media/warning-icon.svg'),
+  });
 
   // Initialize PineDocsManager and PineCompletionService
   // PineDocsManager is accessed via a getter that initializes it if not already.


### PR DESCRIPTION
This commit introduces enhanced visibility for errors and warnings within the Pine Script editor by:

- Highlighting the background of lines containing errors or warnings.
- Adding distinct gutter icons for error and warning lines.

These changes are themeable through new color contributions in `package.json`:
- `pine.errorBackground`
- `pine.warningBackground`
- `pine.errorGutterIcon` (for future use, icons currently use SVG-defined colors)
- `pine.warningGutterIcon` (for future use, icons currently use SVG-defined colors)

The implementation involves:
- Defining new `TextEditorDecorationType`s in `src/extension.ts` for errors and warnings.
- Updating `src/PineLint.ts` to apply these decorations based on diagnostic severity.
- Adding new SVG icons for the gutter indicators.

## Summary by Sourcery

Enhance error and warning visibility in the Pine Script editor by highlighting affected lines and adding gutter icons, configurable via themeable color settings.

New Features:
- Highlight error and warning lines with background decorations in the editor
- Display distinct gutter icons for error and warning diagnostics

Enhancements:
- Introduce themeable color contributions and corresponding TextEditorDecorationTypes for error and warning highlights and gutter icons